### PR TITLE
pyqt instead of pyside2 in run requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - napari = napari.__main__:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - backcall
     - pluggy
     - PyOpenGl
-    - PySide2
+    - pyqt
     - wrapt
     - numpydoc
     - napari-plugin-engine
@@ -63,8 +63,8 @@ test:
   imports:
     - napari
   commands:
-    - setx QT_API "pyside2"  # [win]
-    - export QT_API=pyside2  # [unix]
+    - setx QT_API "pyqt5"  # [win]
+    - export QT_API=pyqt5  # [unix]
     - which napari
     #- DISPLAY=localhost:1.0 xvfb-run -a bash -c 'napari --info'
     #- pytest --pyargs napari


### PR DESCRIPTION
pyqt5 is getting installed anyway by other dependencies... so there's little reason to specify pyside2 in our requirements.  Most people will just end up with both backends.  This PR switches to `pyqt`

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
