### PR TITLE
napari 0.4.15 and vispy 0.10 are incompatible

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "napari" %}
 {% set version = "0.4.15" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 package:
   name: napari-meta
@@ -68,7 +68,7 @@ outputs:
         - typing_extensions
         - toolz >=0.10.0
         - tqdm >=4.56.0
-        - vispy >=0.9.6
+        - vispy >=0.9.6,<0.10
         - wrapt >=1.11.1
 
         # additional dependencies for convenience in conda-forge


### PR DESCRIPTION
This prevents 0.4.15 and vispy 0.10 from being installed together by default.
