### PR TITLE
Do not add sphinx as a runtime dependency

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,11 +16,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,3 +6,5 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pyqt:
+- '5.15'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @AhmetCanSolak @goanpeca @jaimergp @jni @kne42 @royerloic @sofroniewn @tlambert03
+* @AhmetCanSolak @goanpeca @jaimergp @jni @kne42 @royerloic @sofroniewn

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,10 @@ pkgs_dirs:
 
 CONDARC
 
-
-mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
-mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
+mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -12,7 +12,7 @@ function startgroup {
             echo "##[group]$1";;
         travis )
             echo "$1"
-            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:start:'"${1// /}"'\r';;
         github_actions )
             echo "::group::$1";;
         * )
@@ -28,7 +28,7 @@ function endgroup {
         azure )
             echo "##[endgroup]";;
         travis )
-            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:end:'"${1// /}"'\r';;
         github_actions )
             echo "::endgroup::";;
     esac

--- a/README.md
+++ b/README.md
@@ -191,5 +191,4 @@ Feedstock Maintainers
 * [@kne42](https://github.com/kne42/)
 * [@royerloic](https://github.com/royerloic/)
 * [@sofroniewn](https://github.com/sofroniewn/)
-* [@tlambert03](https://github.com/tlambert03/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "napari" %}
 {% set version = "0.4.18" %}
-{% set build = 2 %}
 
 package:
   name: napari-meta
@@ -10,19 +9,20 @@ source:
     sha256: daea9ab94124140fc0f715e945dd1dd6dc3056a1cb2f2cc31fc29b80162943e4
     patches:
       - no-qt-binding-msg.patch  # only for 0.4.18; remove in 0.5!
+      # Sphinx is a documentation dependency, not a runtime dependency
+      - no_sphinx_requirement.patch
   - url: https://raw.githubusercontent.com/napari/napari/v{{ version }}/resources/conda_menu_config.json
     folder: resources
     sha256: 45e8cfe4228fcad9954efe9bc7ffd3502302f740b107bc63d3e241d2cfa89bda
 
 build:
-  number: {{ build }}
+  number: 3
 
 outputs:
   - name: napari
     version: {{ version }}
     build:
       noarch: python
-      number: {{ build }}
       script: PIP_NO_INDEX=True PIP_NO_DEPENDENCIES=True PIP_NO_BUILD_ISOLATION=False PIP_IGNORE_INSTALLED=True PYTHONDONTWRITEBYTECODE=True {{ PREFIX }}/bin/python -m pip install . -vv
       entry_points:
         - napari = napari.__main__:main
@@ -66,7 +66,6 @@ outputs:
         - qtpy >=1.10.0
         - scikit-image >=0.19.1
         - scipy >=1.5.4
-        - sphinx >=4.3.0,<5
         - superqt >=0.4.1
         - tifffile >=2020.2.16
         - toolz >=0.10.0
@@ -124,7 +123,6 @@ outputs:
     version: {{ version }}
     build:
       noarch: python
-      number: {{ build }}
       script:
         - mkdir -p "${PREFIX}/Menu"
         - sed "s/__PKG_VERSION__/{{ PKG_VERSION }}/" "{{ SRC_DIR }}/resources/conda_menu_config.json" > "{{ PREFIX }}/Menu/napari-menu.json"

--- a/recipe/no_sphinx_requirement.patch
+++ b/recipe/no_sphinx_requirement.patch
@@ -1,0 +1,11 @@
+diff -ur a/setup.cfg b/setup.cfg
+--- a/setup.cfg	2023-07-05 01:00:16.755437100 -0400
++++ b/setup.cfg	2023-09-25 04:10:54.032293678 -0400
+@@ -71,7 +71,6 @@
+ 	scikit-image[data]>=0.19.1 # just `pooch`, but needed by `builtins` to provide all scikit-image.data samples
+ 	scipy>=1.4.1 ; python_version < '3.9'
+ 	scipy>=1.5.4 ; python_version >= '3.9'
+-	sphinx>=4.3.0,<5  # numpydoc dependency. sphinx>=5 breaks the docs build; see https://github.com/napari/napari/pull/4915
+ 	superqt>=0.4.1
+ 	tifffile>=2020.2.16
+ 	toolz>=0.10.0


### PR DESCRIPTION
Would it be ok to remove sphinx from a runtime dependency?

The pinning is quite restrictive and I don't think it adds value to an end user that uses the napari GUI.

Thank you for considering
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
