### PR TITLE
Add `napari-base` output and reorganize dependencies

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -43,6 +43,12 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 source run_conda_forge_build_setup
 
+(
+# Due to https://bugzilla.redhat.com/show_bug.cgi?id=1537564 old versions of rpm
+# are drastically slowed down when the number of file descriptors is very high.
+# This can be visible during a `yum install` step of a feedstock build.
+# => Set a lower limit in a subshell for the `yum install`s only.
+ulimit -n 1024
 
 # Install the yum requirements defined canonically in the
 # "recipe/yum_requirements.txt" file. After updating that file,
@@ -51,7 +57,8 @@ source run_conda_forge_build_setup
 /usr/bin/sudo -n yum install -y mesa-libGL-devel xorg-x11-server-Xvfb libXrender mesa-dri-drivers dbus-libs libxkbcommon-x11
 
 
-# make the build number clobber
+
+)# make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 
@@ -77,7 +84,6 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
-
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0

--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ Documentation: http://napari.org
 
 a fast n-dimensional image viewer in Python
 
+About napari-base
+-----------------
+
+Home: http://napari.org
+
+Package license: BSD-3-Clause AND MIT
+
+Summary: a fast n-dimensional image viewer in Python, with only the required dependencies
+
+Development: https://github.com/napari/napari
+
+Documentation: http://napari.org
+
 About napari
 ------------
 
@@ -68,6 +81,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-napari-green.svg)](https://anaconda.org/conda-forge/napari) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/napari.svg)](https://anaconda.org/conda-forge/napari) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/napari.svg)](https://anaconda.org/conda-forge/napari) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/napari.svg)](https://anaconda.org/conda-forge/napari) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-napari--base-green.svg)](https://anaconda.org/conda-forge/napari-base) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/napari-base.svg)](https://anaconda.org/conda-forge/napari-base) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/napari-base.svg)](https://anaconda.org/conda-forge/napari-base) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/napari-base.svg)](https://anaconda.org/conda-forge/napari-base) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-napari--menu-green.svg)](https://anaconda.org/conda-forge/napari-menu) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/napari-menu.svg)](https://anaconda.org/conda-forge/napari-menu) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/napari-menu.svg)](https://anaconda.org/conda-forge/napari-menu) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/napari-menu.svg)](https://anaconda.org/conda-forge/napari-menu) |
 
 Installing napari
@@ -80,16 +94,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `napari, napari-menu` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `napari, napari-base, napari-menu` can be installed with `conda`:
 
 ```
-conda install napari napari-menu
+conda install napari napari-base napari-menu
 ```
 
 or with `mamba`:
 
 ```
-mamba install napari napari-menu
+mamba install napari napari-base napari-menu
 ```
 
 It is possible to list all of the versions of `napari` available on your platform with `conda`:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -121,7 +121,7 @@ outputs:
         - napari-svg >=0.1.8
         - numba >=0.57.1
         - pooch >=1.3.0
-        # - py-triangle  # a bit fragile with bad data, leave out for now
+        # - py-triangle  # can segfault with bad data: https://github.com/napari/napari/pull/6654
         - zarr >=2.12.0
     test:  # just to check that the environment can indeed solve
       requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: 3920b144d72e8af8fe0da3da679b2d39aa2d097c10a2c75a3b4e42ffcef17cac
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: napari

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -115,7 +115,7 @@ outputs:
       noarch: python
     requirements:
       run:
-        - {{ pin_subpackage('napari-base', exact=True )}}
+        - {{ pin_subpackage('napari-base', exact=True) }}
         - fsspec
         - napari-plugin-manager >=0.1.0a2,<0.3.0a0
         - napari-svg >=0.1.8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,7 @@ outputs:
         - magicgui >=0.7.0
         - napari-console >=0.0.9
         - napari-plugin-engine >=0.1.9
+        - napari-plugin-manager >=0.1.0a2
         - napari-svg >=0.1.8
         - npe2 >=0.7.6
         - numpy >=1.22.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,10 @@ source:
     sha256: 3920b144d72e8af8fe0da3da679b2d39aa2d097c10a2c75a3b4e42ffcef17cac
 
 build:
-  number: 1
+  number: 2
 
 outputs:
-  - name: napari
+  - name: napari-base
     version: {{ version }}
     build:
       noarch: python
@@ -49,8 +49,6 @@ outputs:
         - magicgui >=0.7.0
         - napari-console >=0.0.9
         - napari-plugin-engine >=0.1.9
-        - napari-plugin-manager >=0.1.0a2
-        - napari-svg >=0.1.8
         - npe2 >=0.7.6
         - numpy >=1.22.2
         - numpydoc >=0.9.2
@@ -74,19 +72,10 @@ outputs:
         - vispy >=0.14.1,<0.15.0a0
         - wrapt >=1.11.1
 
-        # additional dependencies for convenience in conda-forge
-        - fsspec
-        - pooch >=1.3.0
-        - zarr >=2.12.0
-
       run_constrained:
-        - napari-plugin-manager >=0.1.0a2,<0.3.0a0
         - pyside2 >=5.13.2,!=5.15.0
         - pyside6 <6.5|>=6.7
         - pyqt >=5.12.3,!=5.15.0,<6.0a0|>=6.5,!=6.6.1
-        # Nice for performance, but optional. Inclusion under discussion.
-        # - py-triangle
-        # - numba >=0.57.1  # https://github.com/napari/napari/pull/6467#issuecomment-1819038165
 
     test:
       requires:
@@ -116,6 +105,33 @@ outputs:
         - LICENSE
         - napari/_vendor/darkdetect/LICENSE
         - napari/_vendor/qt_json_builder/LICENSE
+      summary: a fast n-dimensional image viewer in Python, with only the required dependencies
+      doc_url: http://napari.org
+      dev_url: https://github.com/napari/napari
+
+  - name: napari
+    version: {{ version }}
+    build:
+      noarch: python
+    requirements:
+      run:
+        - {{ pin_subpackage('napari-base', exact=True )}}
+        - fsspec
+        - napari-plugin-manager >=0.1.0a2,<0.3.0a0
+        - napari-svg >=0.1.8
+        - numba >=0.57.1
+        - pooch >=1.3.0
+        # - py-triangle  # a bit fragile with bad data, leave out for now
+        - zarr >=2.12.0
+    test:  # just to check that the environment can indeed solve
+      requires:
+        - pyside2  # use this opportunity to test solvability with other backend
+      imports:
+        - napari
+    about:
+      home: http://napari.org
+      license: BSD-3-Clause AND MIT
+      license_file: LICENSE
       summary: a fast n-dimensional image viewer in Python
       description: a fast n-dimensional image viewer in Python
       doc_url: http://napari.org


### PR DESCRIPTION
Closes https://github.com/conda-forge/napari-feedstock/issues/62
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Need a repo patch too I think?

---

> Edit by @jaimergp:

I've added a new output, `napari-base`, following conversation in this PR, this [Zulip thread](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/.E2.9C.94.20The.20plugin.20.22install.2Funinstall.22.20button.20not.20shown.20in.20.22Plu.2E.2E.2E), and [this other one](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/napari.20plugin.20manager.20in.20conda.20recipe).

With this PR we will have these outputs:

* `napari-base`: the core library, with only the required dependencies. Use it for your Pyhton imports but no GUI action.
* `napari`: the application sans the Qt backend. It contains optional yet recommended dependencies for (performant) GUI usage, like the plugin manager or `numba`. 
* `napari-menu`: just the `menuinst` JSON file, in case you want a desktop shortcut.

Most end-users will want to `conda install napari pyqt` or `conda install napari pyside2`.