### PR TITLE
Unblock pyopengl and fix the windows dependency.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     sha256: 3920b144d72e8af8fe0da3da679b2d39aa2d097c10a2c75a3b4e42ffcef17cac
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: napari-base
@@ -61,10 +61,10 @@ outputs:
         - psygnal >=0.5.0
         - pydantic >=2.2.0
         - pygments >=2.6.0
-        - pyopengl >=3.1.5  # [not linux]
-        - pyopengl >=3.1.5,!=3.1.7,!=3.1.9  # [linux]
+        - pyopengl >=3.1.5
         - python-dotenv >=0.21.0
-        - pywin32 >=302  # [win]
+        # only needed for windows, but helps keep the package noarch
+        - pywin32 >=302
         - pyyaml >=6.0
         - qtpy >=1.10.0
         - scikit-image >=0.19.1


### PR DESCRIPTION
Alternative to: https://github.com/conda-forge/napari-feedstock/pull/80 keeps everything simple in light of the findings in https://github.com/conda-forge/pyopengl-feedstock/pull/30#issuecomment-2850792274

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
